### PR TITLE
@hotfix/filter-by-topic 사이드메뉴의 관심/전문분야 토픽 리스트 수정 #52

### DIFF
--- a/Nanum-Project/src/app/main/main-left/main-left.component.html
+++ b/Nanum-Project/src/app/main/main-left/main-left.component.html
@@ -1,0 +1,18 @@
+<div class="sidebar">
+  <h1 class="sidebar_header mat-h1">피드</h1>
+  <div class="sidebar_lists">
+    <ul class="sidebar_filters mat-caption" (click)="clickGeneralMenu($event)">
+      <li><a href="#" [routerLink]="[]"><i class="material-icons">trending_up</i>최신 글</a></li>
+      <li><a href="#" [routerLink]="[]"><i class="material-icons">bookmark_border</i>북마크한 답변</a></li>
+      <li><a href="#" [routerLink]="[]"><i class="material-icons">whatshot</i>인기글</a></li>
+    </ul>
+    <div class="sidebar_edit mat-caption">
+      <span><i class="material-icons">folder_special</i>내 토픽</span>
+    </div>
+    <ul class="sidebar_topics mat-caption" (click)="clickTopicMenu($event)">
+      <li *ngFor="let topic of topics; let i = index" [attr.data-id]="topic.pk">
+        <a href="#" [routerLink]="[]">{{topic.name}}</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/Nanum-Project/src/app/main/main-left/main-left.component.ts
+++ b/Nanum-Project/src/app/main/main-left/main-left.component.ts
@@ -1,63 +1,43 @@
 import { Component, OnInit } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { MenuService } from '../../service/menu.service';
-import { AppService } from '../../app.service';
+import { ActivatedRoute } from '@angular/router';
+
 
 interface Topic {
-  topics: {
-    pk: number;
-    name: string;
-  };
+  pk: number;
+  name: string;
+  image: string;
+  follow_relation_pk: number;
 }
 
 @Component({
   selector: 'app-main-left',
-  // templateUrl: './main-left.component.html',
-  template: `
-  <div class="sidebar">
-  <h1 class="sidebar_header mat-h1">피드</h1>
-  <div class="sidebar_lists">
-    <ul class="sidebar_filters mat-caption" (click)="clickGeneralMenu($event)">
-      <li><a href="#" [routerLink]="[]"><i class="material-icons">trending_up</i>최신 글</a></li>
-      <li><a href="#" [routerLink]="[]"><i class="material-icons">bookmark_border</i>북마크한 답변</a></li>
-      <li><a href="#" [routerLink]="[]"><i class="material-icons">whatshot</i>인기글</a></li>
-    </ul>
-    <div class="sidebar_edit mat-caption">
-      <span><i class="material-icons">folder_special</i>내 토픽</span>
-    </div>
-    <ul class="sidebar_topics mat-caption" (click)="clickTopicMenu($event)">
-      <li *ngFor="let topic of topics; let i = index" [attr.data-id]="topic.topics.pk">
-        <a href="#" [routerLink]="[]">{{topic.topics.name}}</a>
-      </li>
-    </ul>
-  </div>
-</div>
-  `,
+  templateUrl: './main-left.component.html',
   styleUrls: ['./main-left.component.css']
 })
-export class MainLeftComponent implements OnInit {
-  topics: Topic[];
-  private headers = new HttpHeaders()
-    .set('Authorization', `Token ${JSON.parse(localStorage.getItem('currentUser')).token}`);
 
-  constructor(private menu: MenuService, private http: HttpClient, private path: AppService) {
-   }
+export class MainLeftComponent implements OnInit {
+  private PARAMETERS = {
+    question: 'expertise',
+    answer: 'interests'
+  };
+  private parameter: string = this.PARAMETERS[this.route.snapshot.url.join()];
+  public topics: Topic[];
+
+  constructor(private route: ActivatedRoute, private menuService: MenuService) { }
 
   ngOnInit() {
-    this.getTopics();
-  }
-
-  getTopics() {
-    // question과 answer를 분기 해야 하지만 answer관련해서 api가 존재하지 않음
-    this.http.get(this.path.api_path + '/post/question/filter/', { headers: this.headers })
-      .subscribe((res: Topic[]) => { this.topics = res; });
+    this.menuService.getFavoriteTopics(this.parameter).subscribe(
+      res => { this.topics = res.results; },
+      err => console.log(err)
+    );
   }
 
   clickGeneralMenu(event) {
-    this.menu.selLeftMenu = event.target.querySelector('i').textContent;
+    this.menuService.selLeftMenu = event.target.querySelector('i').textContent;
   }
 
   clickTopicMenu(event) {
-    this.menu.selLeftMenu = 'topic';
+    this.menuService.selLeftMenu = 'topic';
   }
 }

--- a/Nanum-Project/src/app/service/menu.service.ts
+++ b/Nanum-Project/src/app/service/menu.service.ts
@@ -1,9 +1,46 @@
 import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+
+import { HOST } from '../shared/configs';
+
+
+interface User {
+  pk: number;
+  email: string;
+  name: string;
+  thumbnail_image_25: string;
+  thumbnail_image_50: string;
+}
+
+interface FavTopics {
+  count: number;
+  next: null|string;
+  previous: null|number;
+  results: Topic[];
+}
+
+interface Topic {
+  pk: number;
+  name: string;
+  image: string;
+  follow_relation_pk: number;
+}
 
 @Injectable()
 export class MenuService {
+  private headers = new HttpHeaders().set(
+    'Authorization',
+    `Token ${JSON.parse(localStorage.currentUser).token}`);
+  public user: User = JSON.parse(localStorage.currentUser).user;
+
   selMainMenu = 'answer';
   selLeftMenu = 'popular';
-  constructor() { }
+  constructor(private http: HttpClient) { }
 
+  getFavoriteTopics(type = 'expertise') {
+    return this.http.get<FavTopics>(
+      `${HOST}/user/${this.user.pk}/following-${type}/?page=1&page_size=3`,
+      { headers: this.headers }
+    );
+  }
 }

--- a/Nanum-Project/src/app/shared/feed/feed.service.ts
+++ b/Nanum-Project/src/app/shared/feed/feed.service.ts
@@ -83,33 +83,40 @@ export class FeedService {
   constructor(private http: HttpClient) { }
 
   // type = question | answer | comment
-  getFirstPage(type = 'answer', urlParameters: string[] = ['ordering=-created_at']) {
-    return this.http.get<Page>(`${HOST}/post/${type === 'topic' ? 'question' : type }/?${urlParameters.join('&')}`,
+  getFirstPage(type: string = 'answer', urlParameters: string[] = ['ordering=-created_at']) {
+    return this.http.get<Page>(
+      `${HOST}/post/${type === 'topic' ? 'question' : type }/?${urlParameters.join('&')}`,
       { headers: this.headers });
   }
 
   // question, answer, comment 공통
   fetchNextPage(nextURL) {
-    return this.http.get<Page>(nextURL, { headers: this.headers });
+    return this.http.get<Page>(
+      nextURL, { headers: this.headers });
   }
 
   getParentQuestion(url) {
-    return this.http.get<QuestionDetail>(url, { headers: this.headers });
+    return this.http.get<QuestionDetail>(
+      url, { headers: this.headers });
   }
 
   getTopicDetail(url) {
-    return this.http.get<Topic>(url, { headers: this.headers });
+    return this.http.get<Topic>(
+      url, { headers: this.headers });
   }
 
   getAuthorProfile(url) {
-    return this.http.get<Profile>(url, { headers: this.headers });
+    return this.http.get<Profile>(
+      url, { headers: this.headers });
   }
 
   postComment(payload) {
-    return this.http.post<Comment>(`${HOST}/post/comment/`, payload, { headers: this.headers });
+    return this.http.post<Comment>(
+      `${HOST}/post/comment/`, payload, { headers: this.headers });
   }
 
   postAnswer(payload) {
-    return this.http.post<Answer>(`${HOST}/post/answer/`, payload, { headers: this.headers });
+    return this.http.post<Answer>(
+      `${HOST}/post/answer/`, payload, { headers: this.headers });
   }
 }


### PR DESCRIPTION
**변경사항**

- main-left.component
  - template 별도 파일로 분리
  - response 타입 변경으로 타이핑, 템플릿 수정
  - server 통신 로직을 서비스로 분리
- menu.service
  - 관심|전문 토픽 요청 URL 변경
  - 질문|답변 라우터 상태에 따라서 요청 URL 분리
  - user PK 데이터를 보관하는 코드 추가

others

- feed.service
  - 4칸 indent를 고려해서 줄바꿈 수정